### PR TITLE
Composer throws runtime exception

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,6 +12,6 @@
     "minimum-stability": "dev",
     "require": {},
     "autoload": {
-        "classmap": ["oneapi/", "oneapi/models", "oneapi/Utils", "oneapi/models/iam", "oneapi/models/two-factor-authentication"]
+        "classmap": ["oneapi/", "oneapi/models", "oneapi/utils", "oneapi/models/iam", "oneapi/models/two-factor-authentication"]
     }
 }


### PR DESCRIPTION
Composer throws runtime exception because there is a syntax mistake in the classpath.

[RuntimeException]  
  Could not scan for classes inside "/var/www/html/marko/vendor/infobip/oneapi/oneapi/Utils" which does not appear to be a file nor a folder              

The Utils directory should be specified with a lowercase u.
