### PR TITLE
Fix short opening tag on DeliveryInfoNotification class

### DIFF
--- a/oneapi/models/DeliveryInfoNotification.php
+++ b/oneapi/models/DeliveryInfoNotification.php
@@ -1,4 +1,4 @@
-<?
+<?php
 
 namespace infobip\models;
 

--- a/oneapi/models/TerminalRoamingStatusNotification.php
+++ b/oneapi/models/TerminalRoamingStatusNotification.php
@@ -1,4 +1,4 @@
-<?
+<?php
 
 namespace infobip\models;
 

--- a/tests/delivery_info_notification_unserialize.php
+++ b/tests/delivery_info_notification_unserialize.php
@@ -1,4 +1,4 @@
-<?
+<?php
 
 use infobip\SmsClient;
 

--- a/tests/terminal_roaming_status_unserialize.php
+++ b/tests/terminal_roaming_status_unserialize.php
@@ -1,4 +1,4 @@
-<?
+<?php
 
 use infobip\DataConnectionProfileClient;
 


### PR DESCRIPTION
Short opening tag in DeliveryInfoNotification class was causing classname resolution error